### PR TITLE
更新 InitializeWeapons 武器初始化逻辑

### DIFF
--- a/Assets/Scripts/Weapons/Core/PlayerWeaponController.cs
+++ b/Assets/Scripts/Weapons/Core/PlayerWeaponController.cs
@@ -408,7 +408,24 @@ namespace DWHITE.Weapons
             if (_availableWeapons.Count == 0)
             {
                 WeaponBase[] childWeapons = GetComponentsInChildren<WeaponBase>(true);
-                _availableWeapons.AddRange(childWeapons);
+                foreach (var weapon in childWeapons)
+                {
+                    if (!_availableWeapons.Contains(weapon))
+                        _availableWeapons.Add(weapon);
+                }
+            }
+
+            // 移除空引用
+            _availableWeapons.RemoveAll(w => w == null);
+
+            // 设置父对象
+            if (_weaponContainer != null)
+            {
+                foreach (var weapon in _availableWeapons)
+                {
+                    if (weapon.transform.parent != _weaponContainer)
+                        weapon.transform.SetParent(_weaponContainer, false);
+                }
             }
             
             // 初始化所有武器为未装备状态


### PR DESCRIPTION
## Summary
- 初始化武器时，避免重复并移除空引用
- 将找到的武器统一设置到 weaponContainer 下

## Testing
- `csc Assets/Scripts/Weapons/Core/PlayerWeaponController.cs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eb5d0735c832bb74e988f564655a6